### PR TITLE
Update forwarding status after service deletion

### DIFF
--- a/api/networking/v1alpha1/portforwarding_types.go
+++ b/api/networking/v1alpha1/portforwarding_types.go
@@ -120,6 +120,7 @@ const (
 	PortForwardingResidual PortForwardingState = "Residual"
 	PortForwardingFailed   PortForwardingState = "Failed"
 	PortForwardingUnknown  PortForwardingState = "Unknown"
+	PortForwardingNoTarget PortForwardingState = "NoTarget"
 )
 
 const (


### PR DESCRIPTION
When deleting a service resource object during a port forwarding event, the process is not handled correctly.